### PR TITLE
Update Frames.lua

### DIFF
--- a/Frames.lua
+++ b/Frames.lua
@@ -71,7 +71,7 @@ function MainFrame:OnInitialize()
 end
 
 function DeleteButtonFrame:OnInitialize()
-    self.frame = CreateFrame("BUTTON", addonName .. "DeleteButtonFrame", MainFrame.frame, "SquareIconButtonTemplate,CustomizeFrameWithTooltipTemplate")
+    self.frame = CreateFrame("BUTTON", addonName .. "DeleteButtonFrame", MainFrame.frame, "SquareIconButtonTemplate,CustomizationFrameWithTooltipTemplate")
 
     prepareTooltipOptions(self.frame, "Delete")
 
@@ -85,7 +85,7 @@ function DeleteButtonFrame:OnInitialize()
 end
 
 function LoadButtonFrame:OnInitialize()
-    self.frame = CreateFrame("BUTTON", addonName .. "LoadButtonFrame", MainFrame.frame, "SquareIconButtonTemplate,CustomizeFrameWithTooltipTemplate")
+    self.frame = CreateFrame("BUTTON", addonName .. "LoadButtonFrame", MainFrame.frame, "SquareIconButtonTemplate,CustomizationFrameWithTooltipTemplate")
 
     prepareTooltipOptions(self.frame, "Load")
 
@@ -205,7 +205,7 @@ function ProfilePickerFrame:SetValue(newValue)
 end
 
 function SaveButtonFrame:OnInitialize()
-    self.frame = CreateFrame("BUTTON", addonName .. "SaveButtonFrame", MainFrame.frame, "SquareIconButtonTemplate,CustomizeFrameWithTooltipTemplate")
+    self.frame = CreateFrame("BUTTON", addonName .. "SaveButtonFrame", MainFrame.frame, "SquareIconButtonTemplate,CustomizationFrameWithTooltipTemplate")
 
     prepareTooltipOptions(self.frame, "Save")
 

--- a/Frames.lua
+++ b/Frames.lua
@@ -71,7 +71,7 @@ function MainFrame:OnInitialize()
 end
 
 function DeleteButtonFrame:OnInitialize()
-    self.frame = CreateFrame("BUTTON", addonName .. "DeleteButtonFrame", MainFrame.frame, "SquareIconButtonTemplate,CharCustomizeFrameWithTooltipTemplate")
+    self.frame = CreateFrame("BUTTON", addonName .. "DeleteButtonFrame", MainFrame.frame, "SquareIconButtonTemplate,CustomizeFrameWithTooltipTemplate")
 
     prepareTooltipOptions(self.frame, "Delete")
 
@@ -85,7 +85,7 @@ function DeleteButtonFrame:OnInitialize()
 end
 
 function LoadButtonFrame:OnInitialize()
-    self.frame = CreateFrame("BUTTON", addonName .. "LoadButtonFrame", MainFrame.frame, "SquareIconButtonTemplate,CharCustomizeFrameWithTooltipTemplate")
+    self.frame = CreateFrame("BUTTON", addonName .. "LoadButtonFrame", MainFrame.frame, "SquareIconButtonTemplate,CustomizeFrameWithTooltipTemplate")
 
     prepareTooltipOptions(self.frame, "Load")
 
@@ -205,7 +205,7 @@ function ProfilePickerFrame:SetValue(newValue)
 end
 
 function SaveButtonFrame:OnInitialize()
-    self.frame = CreateFrame("BUTTON", addonName .. "SaveButtonFrame", MainFrame.frame, "SquareIconButtonTemplate,CharCustomizeFrameWithTooltipTemplate")
+    self.frame = CreateFrame("BUTTON", addonName .. "SaveButtonFrame", MainFrame.frame, "SquareIconButtonTemplate,CustomizeFrameWithTooltipTemplate")
 
     prepareTooltipOptions(self.frame, "Save")
 


### PR DESCRIPTION
Resolves #5 

Resolves an error with CharCustomizeFrameWithTooltipTemplate causing the addon to break. 

Simply changing to CustomizationFrameWithTooltipTemplate in all three cases resolves.